### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate, Llama2 CodeLlama (100+LLMs) [LiteLLM]

### DIFF
--- a/retrieval/pred.py
+++ b/retrieval/pred.py
@@ -1,6 +1,7 @@
 import os
 from datasets import load_dataset
 import torch
+import litellm
 import json
 from transformers import AutoTokenizer, AutoModel, LlamaTokenizer, LlamaForCausalLM, AutoModelForCausalLM
 from tqdm import tqdm
@@ -50,8 +51,8 @@ def get_pred(model, tokenizer, data, max_length, max_gen, prompt_format, dataset
             json_obj['context'] = "".join(json_obj['retrieved'][:args.top_k])
         prompt = prompt_format.format(**json_obj)
         prompt = build_chat(tokenizer, prompt, model_name)
-        if "chatgpt" in model_name:
-            output = openai.ChatCompletion.create(model="gpt-3.5-turbo-16k",
+        if model_name in litellm.model_list:
+            output = litellm.completion(model="gpt-3.5-turbo-16k",
                  messages=[{"role": "user", "content": prompt}], max_tokens=max_gen,
                  temperature=1.0)
             pred = output['choices'][0]['message']['content']

--- a/retrieval/requirements.txt
+++ b/retrieval/requirements.txt
@@ -1,3 +1,4 @@
 rank_bm25
 openai
+litellm
 beir


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```